### PR TITLE
start_httpd - use ReuseAddr so we can rebind to a TIME_WAIT port

### DIFF
--- a/Cassandane/Instance.pm
+++ b/Cassandane/Instance.pm
@@ -1062,7 +1062,8 @@ sub start_httpd {
 
         my $httpd = HTTP::Daemon->new(
             LocalAddr => $host,
-            LocalPort => $port
+            LocalPort => $port,
+            ReuseAddr => 1, # Reuse ports left in TIME_WAIT
         ) || die;
         while (my $conn = $httpd->accept) {
             while (my $req = $conn->get_request) {


### PR DESCRIPTION
Previous tests may have shut down the port but not fully so we
must use ReuseAddr when attempting to bind to it or we'll fail
to start the httpd, which will abort the current job with
unhelpful errors